### PR TITLE
Changed unreadable foreground color for invalid

### DIFF
--- a/zenburn.tmTheme
+++ b/zenburn.tmTheme
@@ -355,7 +355,7 @@
 				<key>fontStyle</key>
 				<string>bold italic underline</string>
 				<key>foreground</key>
-				<string>#FF5274</string>
+				<string>#FFCCEE</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Changed unreadable foreground color from:
![image](https://cloud.githubusercontent.com/assets/10941673/7467902/4bb11fc8-f30a-11e4-925e-b51d4b811c7a.png)
to:
![image](https://cloud.githubusercontent.com/assets/10941673/7467903/54956e14-f30a-11e4-9599-9375cbe24eaa.png)
